### PR TITLE
Group related lines together by printed headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,45 +55,76 @@ installation.
 What it sets up
 ---------------
 
-* [Bundler] for managing Ruby libraries
+Mac OS X tools:
+
+* [Homebrew] for managing operating system libraries.
+
+[Homebrew]: http://brew.sh/
+
+Unix tools:
+
 * [Exuberant Ctags] for indexing files for vim tab completion
-* [Foreman] for managing web processes
-* [Hub] for interacting with the GitHub API
-* [Heroku Toolbelt] and [Parity] for interacting with the Heroku API
-* [Homebrew] for managing operating system libraries
-* [ImageMagick] for cropping and resizing images
-* [Node.js] and [NPM], for running apps and installing JavaScript packages
-* [Postgres] for storing relational data
-* [Qt] for headless JavaScript testing via Capybara Webkit
-* [Rbenv] for managing versions of Ruby
+* [Git] for version control
+* [OpenSSL] for Transport Layer Security (TLS)
 * [RCM] for managing company and personal dotfiles
-* [Redis] for storing key-value data
-* [Ruby Build] for installing Rubies
-* [Ruby] stable for writing general-purpose code
 * [The Silver Searcher] for finding things in files
 * [Tmux] for saving project state and switching between projects
 * [Zsh] as your shell
 
-[Bundler]: http://bundler.io/
 [Exuberant Ctags]: http://ctags.sourceforge.net/
-[Foreman]: https://github.com/ddollar/foreman
-[Hub]: http://hub.github.com/
-[Heroku Toolbelt]: https://toolbelt.heroku.com/
-[Homebrew]: http://brew.sh/
-[ImageMagick]: http://www.imagemagick.org/
-[Node.js]: http://nodejs.org/
-[NPM]: https://www.npmjs.org/
-[Parity]: https://github.com/thoughtbot/parity
-[Postgres]: http://www.postgresql.org/
-[Qt]: http://qt-project.org/
-[Rbenv]: https://github.com/sstephenson/rbenv
+[Git]: https://git-scm.com/
+[OpenSSL]: https://www.openssl.org/
 [RCM]: https://github.com/thoughtbot/rcm
-[Redis]: http://redis.io/
-[Ruby Build]: https://github.com/sstephenson/ruby-build
-[Ruby]: https://www.ruby-lang.org/en/
 [The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
 [Tmux]: http://tmux.github.io/
 [Zsh]: http://www.zsh.org/
+
+Heroku tools:
+
+* [Heroku Toolbelt] and [Parity] for interacting with the Heroku API
+
+[Heroku Toolbelt]: https://toolbelt.heroku.com/
+[Parity]: https://github.com/thoughtbot/parity
+
+GitHub tools:
+
+* [Hub] for interacting with the GitHub API
+
+[Hub]: http://hub.github.com/
+
+Image tools:
+
+* [ImageMagick] for cropping and resizing images
+
+Testing tools:
+
+* [Qt] for headless JavaScript testing via Capybara Webkit
+
+[Qt]: http://qt-project.org/
+
+Programming languages and configuration:
+
+* [Bundler] for managing Ruby libraries
+* [Node.js] and [NPM], for running apps and installing JavaScript packages
+* [Rbenv] for managing versions of Ruby
+* [Ruby Build] for installing Rubies
+* [Ruby] stable for writing general-purpose code
+
+[Bundler]: http://bundler.io/
+[ImageMagick]: http://www.imagemagick.org/
+[Node.js]: http://nodejs.org/
+[NPM]: https://www.npmjs.org/
+[Rbenv]: https://github.com/sstephenson/rbenv
+[Ruby Build]: https://github.com/sstephenson/ruby-build
+[Ruby]: https://www.ruby-lang.org/en/
+
+Databases:
+
+* [Postgres] for storing relational data
+* [Redis] for storing key-value data
+
+[Postgres]: http://www.postgresql.org/
+[Redis]: http://redis.io/
 
 It should take less than 15 minutes to install (depends on your machine).
 
@@ -107,13 +138,8 @@ For example:
 ```sh
 #!/bin/sh
 
-brew cask install dropbox
-brew cask install google-chrome
-brew cask install rdio
-
-gem_install_or_update 'parity'
-
-brew_install_or_upgrade 'tree'
+brew_install_or_upgrade 'go'
+brew_install_or_upgrade 'ngrok'
 brew_install_or_upgrade 'watch'
 ```
 
@@ -121,7 +147,9 @@ Write your customizations such that they can be run safely more than once.
 See the `mac` script for examples.
 
 Laptop functions such as `fancy_echo`,
-`brew_install_or_upgrade`, and
+`brew_install_or_upgrade`,
+`brew_tap`,
+`brew_launchctl_restart`, and
 `gem_install_or_update`
 can be used in your `~/.laptop.local`.
 

--- a/mac
+++ b/mac
@@ -57,13 +57,9 @@ esac
 brew_install_or_upgrade() {
   if brew_is_installed "$1"; then
     if brew_is_upgradable "$1"; then
-      fancy_echo "Upgrading %s ..." "$1"
       brew upgrade "$@"
-    else
-      fancy_echo "Already using the latest version of %s. Skipping ..." "$1"
     fi
   else
-    fancy_echo "Installing %s ..." "$1"
     brew install "$@"
   fi
 }
@@ -96,7 +92,6 @@ brew_launchctl_restart() {
   local domain="homebrew.mxcl.$name"
   local plist="$domain.plist"
 
-  fancy_echo "Restarting %s ..." "$1"
   mkdir -p "$HOME/Library/LaunchAgents"
   ln -sfv "/usr/local/opt/$name/$plist" "$HOME/Library/LaunchAgents"
 
@@ -108,10 +103,8 @@ brew_launchctl_restart() {
 
 gem_install_or_update() {
   if gem list "$1" --installed > /dev/null; then
-    fancy_echo "Updating %s ..." "$1"
     gem update "$@"
   else
-    fancy_echo "Installing %s ..." "$1"
     gem install "$@"
     rbenv rehash
   fi
@@ -128,8 +121,6 @@ if ! command -v brew >/dev/null; then
     append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
 
     export PATH="/usr/local/bin:$PATH"
-else
-  fancy_echo "Homebrew already installed. Skipping ..."
 fi
 
 if brew list | grep -Fq brew-cask; then
@@ -141,41 +132,51 @@ fancy_echo "Updating Homebrew formulae ..."
 brew_tap 'thoughtbot/formulae'
 brew update
 
-brew_install_or_upgrade 'zsh'
-brew_install_or_upgrade 'git'
-brew_install_or_upgrade 'postgres'
-brew_launchctl_restart 'postgresql'
-brew_install_or_upgrade 'redis'
-brew_launchctl_restart 'redis'
-brew_install_or_upgrade 'the_silver_searcher'
-brew_install_or_upgrade 'vim'
+fancy_echo "Updating Unix tools ..."
 brew_install_or_upgrade 'ctags'
-brew_install_or_upgrade 'tmux'
+brew_install_or_upgrade 'git'
+brew_install_or_upgrade 'openssl'
+brew unlink openssl && brew link openssl --force
+brew_install_or_upgrade 'rcm'
 brew_install_or_upgrade 'reattach-to-user-namespace'
-brew_install_or_upgrade 'imagemagick'
-brew_install_or_upgrade 'qt'
-brew_install_or_upgrade 'hub'
-brew_install_or_upgrade 'node'
+brew_install_or_upgrade 'the_silver_searcher'
+brew_install_or_upgrade 'tmux'
+brew_install_or_upgrade 'vim'
+brew_install_or_upgrade 'zsh'
+
+fancy_echo "Updating Heroku tools ..."
 brew_install_or_upgrade 'heroku-toolbelt'
 brew_install_or_upgrade 'parity'
-brew_install_or_upgrade 'rcm'
 
+fancy_echo "Updating GitHub tools ..."
+brew_install_or_upgrade 'hub'
+
+fancy_echo "Updating image tools ..."
+brew_install_or_upgrade 'imagemagick'
+
+fancy_echo "Updating testing tools ..."
+brew_install_or_upgrade 'qt'
+
+fancy_echo "Updating programming languages ..."
+brew_install_or_upgrade 'libyaml'
+brew_install_or_upgrade 'node'
 brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
 
-# shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
+fancy_echo "Updating databases ..."
+brew_install_or_upgrade 'postgres'
+brew_install_or_upgrade 'redis'
+brew_launchctl_restart 'postgresql'
+brew_launchctl_restart 'redis'
 
-brew_install_or_upgrade 'openssl'
-brew unlink openssl && brew link openssl --force
-brew_install_or_upgrade 'libyaml'
-
+fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {
   rbenv install -l | grep -v - | tail -1 | sed -e 's/^ *//'
 }
 
 ruby_version="$(find_latest_ruby)"
-
+# shellcheck disable=SC2016
+append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
 eval "$(rbenv init -)"
 
 if ! rbenv versions | grep -Fq "$ruby_version"; then
@@ -184,16 +185,13 @@ fi
 
 rbenv global "$ruby_version"
 rbenv shell "$ruby_version"
-
 gem update --system
-
 gem_install_or_update 'bundler'
-
-fancy_echo "Configuring Bundler ..."
-  number_of_cores=$(sysctl -n hw.ncpu)
-  bundle config --global jobs $((number_of_cores - 1))
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
 
 if [ -f "$HOME/.laptop.local" ]; then
+  fancy_echo "Running your customizations from ~/.laptop.local ..."
   # shellcheck disable=SC1090
   . "$HOME/.laptop.local"
 fi


### PR DESCRIPTION
Sections:
- "Installing Homebrew packages ..."
- "Restarting services ..."
- "Relinking OpenSSL ..."
- "Configuring Ruby ..."
- "Running your customizations from ~/.laptop.local ..."
- "Cleaning up old Homebrew formulas ..."

Related:
- To make that work in the desired way,
  print less noise in the custom functions.
- We don't need parity as customization in README.
- Match documentation to sections, move OpenSSL to Unix section.
- Move libyaml to after OpenSSL, before Ruby.
