### PR TITLE
Check for dead symlinks, relink valid formulae

### DIFF
--- a/mac
+++ b/mac
@@ -83,7 +83,7 @@ brew_is_upgradable() {
 }
 
 brew_tap() {
-  brew tap "$1" 2> /dev/null
+  brew tap "$1" --repair 2> /dev/null
 }
 
 brew_expand_alias() {


### PR DESCRIPTION
Use the [`--repair`](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md) flag to check for dead symlinks
and relink all valid formulae across taps.
